### PR TITLE
更新后可以不向用户暴露host和端口号，当域名解析为隐性URL时很有用

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -204,7 +204,7 @@ function del(the){
 
 function copy(the){
 // 	var url = "https://" + window.location.host;
-	var url = window.location.ancestorOrigins[0];
+	var url = window.location.ancestorOrigins[0];     //域名解析为隐性URL的时候不向用户暴露host和端口
 	url += "/public/data/" + the.name;
 	$('#copy').val(url);
 	var Url2=document.getElementById("copy");

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -203,7 +203,8 @@ function del(the){
 }
 
 function copy(the){
-	var url = "https://" + window.location.host;
+// 	var url = "https://" + window.location.host;
+	var url = window.location.ancestorOrigins[0];
 	url += "/public/data/" + the.name;
 	$('#copy').val(url);
 	var Url2=document.getElementById("copy");


### PR DESCRIPTION
即便是隐形url也可以保持复制后的url一致