### PR TITLE
复制链接地址保持URL一致

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -203,8 +203,10 @@ function del(the){
 }
 
 function copy(the){
-// 	var url = "https://" + window.location.host;
-	var url = window.location.ancestorOrigins[0];     //域名解析为隐性URL的时候不向用户暴露host和端口
+	if(window.location.ancestorOrigins.length!=0)
+		var url = window.location.ancestorOrigins[0];
+	else 
+		var url = window.location.origin;
 	url += "/public/data/" + the.name;
 	$('#copy').val(url);
 	var Url2=document.getElementById("copy");


### PR DESCRIPTION
解决域名为隐形URL时复制链接地址不一致的问题